### PR TITLE
[#12] feat: 대여글 CRUD 구현

### DIFF
--- a/ToyService/src/main/java/com/example/toyservice/controller/LendPostController.java
+++ b/ToyService/src/main/java/com/example/toyservice/controller/LendPostController.java
@@ -1,0 +1,72 @@
+package com.example.toyservice.controller;
+
+import com.example.toyservice.dto.LendPostDto;
+import com.example.toyservice.dto.SellPostDto;
+import com.example.toyservice.model.ResponseResult;
+import com.example.toyservice.service.LendPostService;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@PreAuthorize("hasRole('USER')")
+public class LendPostController {
+	private final LendPostService lendPostService;
+
+	@GetMapping("/members/{memberId}/lend-posts/{postId}")
+	public ResponseEntity<ResponseResult> getLendPost(
+		@PathVariable Long memberId,
+		@PathVariable Long postId) {
+		return ResponseEntity.ok(
+			new ResponseResult(lendPostService.getLendPost(memberId, postId),
+				"대여글을 성공적으로 조회하였습니다."));
+	}
+
+	@GetMapping("/members/{id}/lend-posts")
+	public ResponseEntity<ResponseResult> getLendPosts(@PathVariable Long id) {
+		return ResponseEntity.ok(
+			new ResponseResult(lendPostService.getLendPosts(id),
+				"대여글을 성공적으로 조회하였습니다."));
+	}
+
+	@PostMapping("/members/{id}/lend-posts")
+	public ResponseEntity<ResponseResult> lendPost(
+		@PathVariable Long id,
+		@Valid @RequestBody LendPostDto.Request request) {
+		return ResponseEntity.ok(
+			new ResponseResult(lendPostService.createLendPost(id, request)
+			, "대여게시글이 생성되었습니다.")
+		);
+	}
+
+	@PutMapping("/members/{memberId}/lend-posts/{postId}")
+	public ResponseEntity<ResponseResult> reviseLendPost(
+		@PathVariable Long memberId,
+		@PathVariable Long postId,
+		@Valid @RequestBody LendPostDto.Request request
+	) {
+		return ResponseEntity.ok(
+			new ResponseResult(lendPostService.reviseLendPost(memberId, postId, request)
+				, "대여게시글이 수정되었습니다.")
+		);
+	}
+
+	@DeleteMapping("/members/{memberId}/lend-posts/{postId}")
+	public ResponseEntity<ResponseResult> stopLendPost(
+		@PathVariable Long memberId, @PathVariable Long postId
+	) {
+		return ResponseEntity.ok(
+			new ResponseResult(lendPostService.stop(memberId, postId)
+				, "대여게시글의 거래가 중지되었습니다.")
+		);
+	}
+}

--- a/ToyService/src/main/java/com/example/toyservice/controller/SellPostController.java
+++ b/ToyService/src/main/java/com/example/toyservice/controller/SellPostController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class SellPostController {
 	private final SellPostService sellPostService;
 
-	@GetMapping("/members/{memberId}/posts/{postId}")
+	@GetMapping("/members/{memberId}/sell-posts/{postId}")
 	public ResponseEntity<ResponseResult> getSellPost(
 		@PathVariable Long memberId,
 		@PathVariable Long postId) {
@@ -30,14 +30,14 @@ public class SellPostController {
 				"판매글을 성공적으로 조회하였습니다."));
 	}
 
-	@GetMapping("/members/{id}/posts")
+	@GetMapping("/members/{id}/sell-posts")
 	public ResponseEntity<ResponseResult> getSellPosts(@PathVariable Long id) {
 		return ResponseEntity.ok(
 			new ResponseResult(sellPostService.getSellPosts(id),
 				"판매글을 성공적으로 조회하였습니다."));
 	}
 
-	@PostMapping("/members/{id}/posts")
+	@PostMapping("/members/{id}/sell-posts")
 	public ResponseEntity<ResponseResult> sellPost(
 		@PathVariable Long id,
 		@Valid @RequestBody SellPostDto.Request request) {
@@ -47,7 +47,7 @@ public class SellPostController {
 		);
 	}
 
-	@PutMapping("/members/{memberId}/posts/{postId}")
+	@PutMapping("/members/{memberId}/sell-posts/{postId}")
 	public ResponseEntity<ResponseResult> reviseSellPost(
 		@PathVariable Long memberId,
 		@PathVariable Long postId,
@@ -59,7 +59,7 @@ public class SellPostController {
 		);
 	}
 
-	@DeleteMapping("/members/{memberId}/posts/{postId}")
+	@DeleteMapping("/members/{memberId}/sell-posts/{postId}")
 	public ResponseEntity<ResponseResult> stopSellPost(
 		@PathVariable Long memberId, @PathVariable Long postId
 	) {

--- a/ToyService/src/main/java/com/example/toyservice/dto/LendPostDto.java
+++ b/ToyService/src/main/java/com/example/toyservice/dto/LendPostDto.java
@@ -1,0 +1,71 @@
+package com.example.toyservice.dto;
+
+import com.example.toyservice.model.constants.LendStatus;
+import com.example.toyservice.model.entity.LendPost;
+import com.example.toyservice.model.entity.Member;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.PositiveOrZero;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class LendPostDto {
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	public static class Request {
+		@NotBlank(message = "필수 입력입니다.")
+		@Pattern(regexp = "^.{1,15}$",
+		message = "제목은 1~15자로 입력하세요.")
+		private String title;
+		@NotBlank(message = "필수 입력입니다.")
+		private String toyName;
+		@NotBlank(message = "필수 입력입니다.")
+		private String image;
+		@PositiveOrZero(message = "0이상의 숫자를 입력하세요.")
+		private int period;
+		@NotBlank(message = "필수 입력입니다.")
+		@Pattern(regexp = "^.{1,200}$")
+		private String content;
+		private Member lender;
+
+		public LendPost toEntity() {
+			return LendPost.builder()
+				.title(title)
+				.toyName(toyName)
+				.image(image)
+				.lendPeriod(period)
+				.content(content)
+				.lender(lender)
+				.status(LendStatus.LEND_ING)
+				.build();
+		}
+	}
+
+	@Getter
+	@Setter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class Response {
+		private String title;
+		private String toyName;
+		private String image;
+		private int period;
+		private String content;
+
+		public static Response fromEntity(LendPost lendPost) {
+			return Response.builder()
+				.title(lendPost.getTitle())
+				.toyName(lendPost.getToyName())
+				.image(lendPost.getImage())
+				.period(lendPost.getLendPeriod())
+				.content(lendPost.getContent())
+				.build();
+		}
+	}
+}

--- a/ToyService/src/main/java/com/example/toyservice/dto/LendPostInfo.java
+++ b/ToyService/src/main/java/com/example/toyservice/dto/LendPostInfo.java
@@ -1,0 +1,50 @@
+package com.example.toyservice.dto;
+
+import com.example.toyservice.model.constants.LendStatus;
+import com.example.toyservice.model.entity.LendPost;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.util.CollectionUtils;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LendPostInfo {
+	private long id;
+	private String lenderEmail;
+	private String title;
+	private String toyName;
+	private String image;
+	private int period;
+	private String content;;
+	private LendStatus status;
+
+	public static List<LendPostInfo> of(List<LendPost> lendPosts) {
+		if (CollectionUtils.isEmpty(lendPosts)) {
+			return null;
+		}
+		return lendPosts.stream()
+			.map(LendPostInfo::fromEntity)
+			.collect(Collectors.toList());
+	}
+
+	public static LendPostInfo fromEntity(LendPost lendPost) {
+		return LendPostInfo.builder()
+			.id(lendPost.getId())
+			.lenderEmail(lendPost.getLender().getEmail())
+			.title(lendPost.getTitle())
+			.toyName(lendPost.getToyName())
+			.image(lendPost.getImage())
+			.period(lendPost.getLendPeriod())
+			.content(lendPost.getContent())
+			.status(lendPost.getStatus())
+			.build();
+	}
+}

--- a/ToyService/src/main/java/com/example/toyservice/dto/SellPostInfo.java
+++ b/ToyService/src/main/java/com/example/toyservice/dto/SellPostInfo.java
@@ -10,6 +10,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.util.CollectionUtils;
 
 @Getter
 @Setter
@@ -27,7 +28,7 @@ public class SellPostInfo {
 	private SellStatus status;
 
 	public static List<SellPostInfo> of(List<SellPost> sellPosts) {
-		if (sellPosts == null) {
+		if (CollectionUtils.isEmpty(sellPosts)) {
 			return null;
 		}
 		return sellPosts.stream()

--- a/ToyService/src/main/java/com/example/toyservice/model/constants/ErrorCode.java
+++ b/ToyService/src/main/java/com/example/toyservice/model/constants/ErrorCode.java
@@ -24,7 +24,7 @@ public enum ErrorCode {
 	API_REQUEST_FAIL("api 요청 에러"),
 	NOT_EXIST_ADDRESS("주소가 존재하지 않습니다."),
 	NOT_EXIST_POST("해당 글이 존재하지 않습니다."),
-	NOT_MATCH_SELLER("회원정보가 일치하지 않습니다.")
+	NOT_MATCH_MEMBER("회원정보가 일치하지 않습니다.")
 	;
 
 	private final String description;

--- a/ToyService/src/main/java/com/example/toyservice/model/constants/LendStatus.java
+++ b/ToyService/src/main/java/com/example/toyservice/model/constants/LendStatus.java
@@ -1,0 +1,7 @@
+package com.example.toyservice.model.constants;
+
+public enum LendStatus {
+	LEND_ING,
+	LEND_STOP,
+	LEND_COMPLETE
+}

--- a/ToyService/src/main/java/com/example/toyservice/model/entity/LendPost.java
+++ b/ToyService/src/main/java/com/example/toyservice/model/entity/LendPost.java
@@ -1,0 +1,40 @@
+package com.example.toyservice.model.entity;
+
+import com.example.toyservice.model.constants.LendStatus;
+import com.example.toyservice.model.constants.SellStatus;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Setter
+@Getter
+@ToString
+@Entity
+public class LendPost extends BaseEntity {
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JsonIgnore
+	@JoinColumn(name = "lender_id")
+	private Member lender;
+
+	private String title;
+	private String toyName;
+	private String image;
+	private String content;
+	private int lendPeriod;
+
+	@Enumerated(EnumType.STRING)
+	private LendStatus status;
+}

--- a/ToyService/src/main/java/com/example/toyservice/model/entity/Member.java
+++ b/ToyService/src/main/java/com/example/toyservice/model/entity/Member.java
@@ -56,4 +56,9 @@ public class Member extends BaseEntity {
 		fetch = FetchType.LAZY, orphanRemoval = true)
 	@JsonIgnore
 	private List<SellPost> sellPosts = new ArrayList<>();
+
+	@OneToMany(mappedBy = "lender", cascade = CascadeType.ALL,
+		fetch = FetchType.LAZY, orphanRemoval = true)
+	@JsonIgnore
+	private List<LendPost> lendPosts = new ArrayList<>();
 }

--- a/ToyService/src/main/java/com/example/toyservice/repository/LendPostRepository.java
+++ b/ToyService/src/main/java/com/example/toyservice/repository/LendPostRepository.java
@@ -1,0 +1,10 @@
+package com.example.toyservice.repository;
+
+import com.example.toyservice.model.entity.LendPost;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LendPostRepository extends JpaRepository<LendPost, Long> {
+	List<LendPost> findAllByLenderId(Long id);
+	boolean existsByLenderId(Long id);
+}

--- a/ToyService/src/main/java/com/example/toyservice/service/LendPostService.java
+++ b/ToyService/src/main/java/com/example/toyservice/service/LendPostService.java
@@ -1,0 +1,91 @@
+package com.example.toyservice.service;
+
+import com.example.toyservice.dto.LendPostDto;
+import com.example.toyservice.dto.LendPostInfo;
+import com.example.toyservice.exception.AuthenticationException;
+import com.example.toyservice.model.constants.ErrorCode;
+import com.example.toyservice.model.constants.LendStatus;
+import com.example.toyservice.model.constants.MemberStatus;
+import com.example.toyservice.model.entity.LendPost;
+import com.example.toyservice.model.entity.Member;
+import com.example.toyservice.repository.LendPostRepository;
+import com.example.toyservice.repository.MemberRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+
+@RequiredArgsConstructor
+@Service
+public class LendPostService {
+	private final LendPostRepository lendPostRepository;
+	private final MemberRepository memberRepository;
+	public LendPostDto.Response createLendPost(Long memberId, LendPostDto.Request request) {
+		Member lender = memberRepository.findById(memberId)
+			.orElseThrow(() -> new AuthenticationException(ErrorCode.MEMBER_NOT_FOUND));
+		if (lender.getStatus() == MemberStatus.WITHDRAW) {
+			throw new AuthenticationException(ErrorCode.MEMBER_WITHDRAW);
+		}
+
+		request.setLender(lender);
+
+		return LendPostDto.Response.fromEntity(lendPostRepository.save(request.toEntity()));
+	}
+
+	public List<LendPostInfo> getLendPosts(Long memberId) {
+		List<LendPost> lendPosts = lendPostRepository.findAllByLenderId(memberId);
+
+		if (CollectionUtils.isEmpty(lendPosts)) {
+			throw new AuthenticationException(ErrorCode.NOT_EXIST_POST);
+
+		}
+		validateLender(lendPosts.get(0), memberId);
+
+		return LendPostInfo.of(lendPosts);
+	}
+
+	public LendPostInfo getLendPost(Long memberId, Long postId) {
+		LendPost lendPost = lendPostRepository.findById(postId).orElseThrow(
+			() -> new AuthenticationException(ErrorCode.NOT_EXIST_POST));
+
+		validateLender(lendPost, memberId);
+
+		return LendPostInfo.fromEntity(lendPost);
+	}
+
+	public LendPostDto.Response reviseLendPost(Long memberId, Long postId,
+		LendPostDto.Request request) {
+		LendPost lendPost = lendPostRepository.findById(postId)
+			.orElseThrow( () -> new AuthenticationException(ErrorCode.NOT_EXIST_POST));
+
+		validateLender(lendPost, memberId);
+
+		lendPost.setTitle(request.getTitle());
+		lendPost.setToyName(request.getToyName());
+		lendPost.setImage(request.getImage());
+		lendPost.setLendPeriod(request.getPeriod());
+		lendPost.setContent(request.getContent());
+
+		return LendPostDto.Response.fromEntity(lendPostRepository.save(lendPost));
+	}
+
+	public LendPostInfo stop(Long memberId, Long postId) {
+		LendPost lendPost = lendPostRepository.findById(postId)
+			.orElseThrow( () -> new AuthenticationException(ErrorCode.NOT_EXIST_POST));
+
+		validateLender(lendPost, memberId);
+
+		lendPost.setStatus(LendStatus.LEND_STOP);
+
+		return LendPostInfo.fromEntity(lendPostRepository.save(lendPost));
+	}
+
+	public void validateLender(LendPost lendPost, Long memberId) {
+		if (lendPost.getLender().getId() != memberId) {
+			throw new AuthenticationException(ErrorCode.NOT_MATCH_MEMBER);
+		}
+		if (lendPost.getLender().getStatus() == MemberStatus.WITHDRAW) {
+			throw new AuthenticationException(ErrorCode.MEMBER_WITHDRAW);
+		}
+	}
+}

--- a/ToyService/src/main/java/com/example/toyservice/service/MemberService.java
+++ b/ToyService/src/main/java/com/example/toyservice/service/MemberService.java
@@ -159,6 +159,8 @@ public class MemberService implements UserDetailsService {
 		member.setWallet(null);
 		member.getSellPosts().clear();
 		member.getSellPosts().stream().map(x -> null);
+		member.getLendPosts().clear();
+		member.getLendPosts().stream().map(x -> null);
 
 		return MemberDto.Withdraw.fromEntity(memberRepository.save(member));
 	}

--- a/ToyService/src/main/java/com/example/toyservice/service/SellPostService.java
+++ b/ToyService/src/main/java/com/example/toyservice/service/SellPostService.java
@@ -83,7 +83,7 @@ public class SellPostService {
 
 	public void validateSeller(SellPost sellPost, Long memberId) {
 		if (sellPost.getSeller().getId() != memberId) {
-			throw new AuthenticationException(ErrorCode.NOT_MATCH_SELLER);
+			throw new AuthenticationException(ErrorCode.NOT_MATCH_MEMBER);
 		}
 		if (sellPost.getSeller().getStatus() == MemberStatus.WITHDRAW) {
 			throw new AuthenticationException(ErrorCode.MEMBER_WITHDRAW);


### PR DESCRIPTION
### 변경사항
**AS-IS**
- member와 lendPost 간 연관관계 설정
- lendPost 생성 요청 및 응답을 위한 dto객체 생성
- lendPost 수정 후 정보를 보여줄 수 있는 lendPostInfo 객체 생성
- 대여글(lendPost) CRUD 구현

**TO-BE**
- 대여글 목록 조회 페이징 처리
### 테스트
- [x] api 테스트
